### PR TITLE
Add saving to file functionality for groups

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -63,10 +63,10 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the contents of the person list with a new list of persons.
-     * Ensures that the new list does not contain duplicate persons.
+     * Replaces the contents of the group list with a new list of groups.
+     * Ensures that the new list does not contain duplicate groups.
      *
-     * @param persons The new list of persons.
+     * @param groups The new list of groups.
      */
     public void setGroups(List<Group> groups) {
         this.groups.setGroups(groups);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -63,6 +63,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the person list with a new list of persons.
+     * Ensures that the new list does not contain duplicate persons.
+     *
+     * @param persons The new list of persons.
+     */
+    public void setGroups(List<Group> groups) {
+        this.groups.setGroups(groups);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with new data.
      *
      * @param newData The new data to replace the current address book data.
@@ -70,6 +80,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
         setPersons(newData.getPersonList());
+        setGroups(newData.getGroupList());
     }
 
     //// Person-level operations
@@ -190,6 +201,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("persons", persons)
+                .add("groups", groups)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,5 +14,10 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+    /**
+     * Returns an unmodifiable view of the groups list.
+     * This list will not contain any duplicate groups.
+     */
+    ObservableList<Group> getGroupList();
 
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -34,7 +34,7 @@ public class Group implements Result {
     /**
      * Regular expression to validate group names.
      */
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     /**
      * The name of the group.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,11 +1,13 @@
 package seedu.address.model.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -39,11 +41,19 @@ public class SampleDataUtil {
                 getTagSet("colleagues"))
         };
     }
+    public static Group[] getSampleGroups() {
+        return new Group[] {
+            new Group(new String("Group 1"), new ArrayList<Person>(Arrays.asList(getSamplePersons())))
+        };
+    }
 
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
+        }
+        for (Group sampleGroup : getSampleGroups()) {
+            sampleAb.addGroup(sampleGroup);
         }
         return sampleAb;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,9 +1,7 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,0 +1,86 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Group}.
+ */
+class JsonAdaptedGroup {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Group's %s field is missing!";
+
+    private final String name;
+
+    private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedTag> tags = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedGroup} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedGroup(@JsonProperty("name") String name, @JsonProperty("persons") List<JsonAdaptedPerson> persons,
+            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+        this.name = name;
+        if (persons != null) {
+            this.persons.addAll(persons);
+        }
+        if (tags != null) {
+            this.tags.addAll(tags);
+        }
+    }
+
+    /**
+     * Converts a given {@code Group} into this class for Jackson use.
+     */
+    public JsonAdaptedGroup(Group source) {
+        name = source.getGroupName();
+        persons.addAll(source.getGroupMembers().stream()
+                .map(JsonAdaptedPerson::new)
+                .collect(Collectors.toList()));
+        tags.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted group object into the model's {@code Group} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Group toModelType() throws IllegalValueException {
+        final List<Person> modelPersons = new ArrayList<>();
+        for (JsonAdaptedPerson person : persons) {
+            modelPersons.add(person.toModelType());
+        }
+
+        final List<Tag> modelTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tags) {
+            modelTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Group.isValidGroupName(name)) {
+            throw new IllegalValueException(Group.MESSAGE_CONSTRAINTS);
+        }
+        final String modelName = name;
+
+        return new Group(modelName, modelPersons, modelTags);
+    }
+
+}
+

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -30,7 +30,9 @@ class JsonSerializableAddressBook {
      * Constructs a {@code JsonSerializableAddressBook} with the given persons and groups.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons, @JsonProperty("groups") List<JsonAdaptedGroup> groups) {
+    public JsonSerializableAddressBook(
+        @JsonProperty("persons") List<JsonAdaptedPerson> persons,
+        @JsonProperty("groups") List<JsonAdaptedGroup> groups) {
         this.persons.addAll(persons);
         this.groups.addAll(groups);
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -20,15 +21,18 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_GROUP = "Groups list contains duplicate group(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedGroup> groups = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableAddressBook} with the given persons and groups.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons, @JsonProperty("groups") List<JsonAdaptedGroup> groups) {
         this.persons.addAll(persons);
+        this.groups.addAll(groups);
     }
 
     /**
@@ -38,6 +42,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        groups.addAll(source.getGroupList().stream().map(JsonAdaptedGroup::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +58,13 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addPerson(person);
+        }
+        for (JsonAdaptedGroup jsonAdaptedGroup : groups) {
+            Group group = jsonAdaptedGroup.toModelType();
+            if (addressBook.hasGroup(group)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_GROUP);
+            }
+            addressBook.addGroup(group);
         }
         return addressBook;
     }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -9,5 +9,10 @@
     "phone": "948asdf2424",
     "email": "hans@example.com",
     "address": "4th street"
+  } ],
+  "groups" : [ {
+    "name" : "Group1",
+    "persons" : [ ],
+    "tags" : [ ]
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -4,5 +4,10 @@
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"
+  } ],
+  "groups" : [ {
+    "name" : "Group1",
+    "persons" : [ ],
+    "tags" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -10,5 +10,10 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street"
+  } ],
+  "groups" : [ {
+    "name" : "Group1",
+    "persons" : [ ],
+    "tags" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -4,5 +4,10 @@
     "phone": "9482424",
     "email": "invalid@email!3e",
     "address": "4th street"
+  } ],
+  "groups" : [ {
+    "name" : "Group1",
+    "persons" : [ ],
+    "tags" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -42,5 +42,10 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "tags" : [ ]
+  } ],
+  "groups" : [ {
+    "name" : "Group1",
+    "persons" : [ ],
+    "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -85,7 +86,9 @@ public class AddressBookTest {
 
     @Test
     public void toStringMethod() {
-        String expected = AddressBook.class.getCanonicalName() + "{persons=" + addressBook.getPersonList() + "}";
+        String expected = AddressBook.class.getCanonicalName()
+            + "{persons=" + addressBook.getPersonList()
+            + ", groups=" + addressBook.getGroupList() + "}";
         assertEquals(expected, addressBook.toString());
     }
 
@@ -94,6 +97,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Group> groups = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -102,6 +106,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Group> getGroupList() {
+            return groups;
         }
     }
 


### PR DESCRIPTION
Fixes #77.

Saves groups as a list of person objects.

Also fixed validation regex for group names; should allow spaces in group names.