### PR TITLE
Fix issue with Group name validation

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
@@ -32,7 +32,7 @@ public class AddAssignmentCommandParser implements Parser<AddAssignmentCommand> 
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GROUP, PREFIX_DATE);
         String assignmentName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).toString();
-        String groupName = ParserUtil.parseName(argMultimap.getValue(PREFIX_GROUP).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
         LocalDate deadline = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
 
         return new AddAssignmentCommand(assignmentName, groupName, deadline);

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -26,7 +26,7 @@ public class AddGroupCommandParser implements Parser<AddGroupCommand> {
                     AddGroupCommand.MESSAGE_USAGE));
         }
 
-        String groupName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_NAME).get());
 
         return new AddGroupCommand(groupName);
     }

--- a/src/main/java/seedu/address/logic/parser/AddPersonToGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonToGroupCommandParser.java
@@ -28,8 +28,8 @@ public class AddPersonToGroupCommandParser implements Parser<AddPersonToGroupCom
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON, PREFIX_GROUP);
-        String personName = argMultimap.getValue(PREFIX_PERSON).get();
-        String groupName = argMultimap.getValue(PREFIX_GROUP).get();
+        String personName = ParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
 
         return new AddPersonToGroupCommand(personName, groupName);
     }

--- a/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
@@ -37,7 +37,10 @@ public class EditGroupCommandParser implements Parser<EditGroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditGroupCommand.MESSAGE_USAGE), ive);
         }
-        String newGroupName = argMultimap.getValue(PREFIX_NAME).orElse("");
+        String newGroupName = "";
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            newGroupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_NAME).get());
+        }
         Collection<Tag> tags = ParserUtil.parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).orElse(null);
         return new EditGroupCommand(index, newGroupName, tags);
     }

--- a/src/main/java/seedu/address/logic/parser/GradeAssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeAssignmentCommandParser.java
@@ -36,9 +36,9 @@ public class GradeAssignmentCommandParser implements Parser<GradeAssignmentComma
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON, PREFIX_GROUP, PREFIX_ASSIGNMENT, PREFIX_SCORE);
-        String personName = argMultimap.getValue(PREFIX_PERSON).get();
-        String groupName = argMultimap.getValue(PREFIX_GROUP).get();
-        String assignmentName = argMultimap.getValue(PREFIX_ASSIGNMENT).get();
+        String personName = ParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
+        String assignmentName = ParserUtil.parseName(argMultimap.getValue(PREFIX_ASSIGNMENT).get()).toString();
         Float score = Float.parseFloat(argMultimap.getValue(PREFIX_SCORE).get());
         return new GradeAssignmentCommand(personName, groupName, assignmentName, score);
 

--- a/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
@@ -36,8 +36,8 @@ public class MarkAttendanceCommandParser implements Parser<MarkAttendanceCommand
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON, PREFIX_GROUP, PREFIX_WEEK);
-        String personName = argMultimap.getValue(PREFIX_PERSON).get();
-        String groupName = argMultimap.getValue(PREFIX_GROUP).get();
+        String personName = ParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
         int week = Integer.parseInt(argMultimap.getValue(PREFIX_WEEK).get());
         return new MarkAttendanceCommand(personName, groupName, week);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -54,6 +55,21 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
+    }
+
+    /**
+     * Parses the String group name and validated it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given String violated Message Constraints for Group Name
+     */
+    public static String parseGroupName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!Group.isValidGroupName(trimmedName)) {
+            throw new ParseException(Group.MESSAGE_CONSTRAINTS);
+        }
+        return trimmedName;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ShowAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowAttendanceCommandParser.java
@@ -29,8 +29,8 @@ public class ShowAttendanceCommandParser implements Parser<ShowAttendanceCommand
                     ShowAttendanceCommand.MESSAGE_USAGE));
         }
 
-        String personName = argMultimap.getValue(PREFIX_PERSON).get();
-        String groupName = argMultimap.getValue(PREFIX_GROUP).get();
+        String personName = ParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
 
         return new ShowAttendanceCommand(personName, groupName);
     }

--- a/src/main/java/seedu/address/logic/parser/UnmarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkAttendanceCommandParser.java
@@ -36,8 +36,8 @@ public class UnmarkAttendanceCommandParser implements Parser<UnmarkAttendanceCom
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON, PREFIX_GROUP, PREFIX_WEEK);
-        String personName = argMultimap.getValue(PREFIX_PERSON).get();
-        String groupName = argMultimap.getValue(PREFIX_GROUP).get();
+        String personName = ParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON).get()).toString();
+        String groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
         int week = Integer.parseInt(argMultimap.getValue(PREFIX_WEEK).get());
         return new UnmarkAttendanceCommand(personName, groupName, week);
     }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -38,7 +38,7 @@ public class Group implements Result {
     /**
      * Regular expression to validate group names.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}[\\p{Alnum} ]*";
 
     /**
      * The name of the group.

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
fixes #128 
fixes #152 
fixes #150

Most of the issue stem from non standardized use of `ParserUtil`. This led to messy and hard to follow code logic for Group Name validation.

Fix: Create a `parseGroupName` method in `ParseUtil` class and ensure all string parsing would be done through either `parseName` or `parseGroupName`.

This ensures that validation checks for all string will be performed and all error thrown can be caught by ui effectively.

Additional: 
* Might want to reconsider the regex check for groupName as some special characters such as `-` or `()` makes sense for groupName.
* Might want to consider adding the same validation for Assignment if not similar issue may arise in the future.
